### PR TITLE
Provision also the events submodule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,19 +3,15 @@ The other one is not deprecated, but it is no longer in use
 
 ### How do I get set up? ###
 
-Please read the [official landing page](https://oms-project.atlassian.net) (FIXME) at the documentation central repository
-
-
-
-
+Please read the [official landing page](https://oms-project.atlassian.net/wiki/spaces/OMS) at the documentation central repository
 
 
 * Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and
   [Vagrant](https://www.vagrantup.com/downloads.html).
-* Download [this file](FIXME) and launch it (FOR LINUX USERS ONLY). For windows users, if you want to virtualise linux keep in mind that the machine has to be powerful enough to virtualise at its inside.
-* Visit FIXME in a browser to check if installation was successful.
+* Follow the instruction at the bottom of [this page](https://oms-project.atlassian.net/wiki/display/PROV/The+installation+script%3A+usage) and launch it with your POSIX-compliant shell (= FOR LINUX/OSX USERS ONLY). For windows users, if you want to virtualise linux keep in mind that the machine has to be powerful enough to virtualise at its inside. And you may have to fight with the port forwarding.
+* Visit localhost:8000 in a browser to check if installation was successful.
 
-### Remarks for Windows hosts ###
+### Possibly other remarks for Windows hosts ###
 
 If you use Windows as host (i.e., as development platform), you have to be cautious about a few things:
 
@@ -31,44 +27,3 @@ If you use Windows as host (i.e., as development platform), you have to be cauti
     git submodule update --recursive
 ```
 * You also have to fix symlinks after cloning! See [this article](http://stackoverflow.com/questions/5917249/git-symlinks-in-windows) for more info.
-
-
-### Setup of ports (FIXME) ###
-
-|Host (your computer)|Service|Used by|Guest (the VM)|
-|---|---|---|---|
-|8888|HTTP|apache2|80|
-|4444|LDAP|slapd|389|
-|2222|SSH|sshd|22|
-|---|---|---|---|
-|8800|API|oms-core|8080|
-|8801|consumer|oms-profiles-module|8081|
-
-### Sharing the content of the VM directly so we can work from the host ###
-
-|Your local folder|synced seamless in your VM at|
-|---|---|---|---|
-|ignore/oms-core|/srv/oms-core|
-|ignore/oms-profiles-module|/srv/oms-profiles-module|
-
-### Structure of files and where to touch to modify as you please ###
-
-* Ports: Vagrantfile
-* Synced folders: Vagrantfile
-* Installation and provisioning of the VM: puppet/manifests/site.pp --> __in this file, there are two "classes" used that are defined as per below:__
-  1.  Stuff about installation of LDAP: puppet/modules/aegee_ldap/manifests/init.pp
-  2.  Stuff about installation of OMS: puppet/modules/aegee_oms_modules/manifests/init.pp
-
-### Versions of Node.js and npm ###
-As defined in the manifest, the versions are:
-
-* node 4.1.2
-* npm 2.14.4
-
-(that version of npm is not defined, it is the one shipped with node 4.1.2)
-
-### Puppet version on the guest ###
-As defined in scripts/upgrade_puppet.sh, the release is *puppetlabs-release-trusty.deb* which is fixed at 
-
-* 3.8.6
-

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -32,13 +32,13 @@ databases:
 #       client-token: bar
 
 ports:
-    - send: 80
+    - send: 8180
       to: 8080
-    - send: 8081
+    - send: 8181
       to: 8081
-    - send: 8082
+    - send: 8182
       to: 8082
-    - send: 8083
+    - send: 8183
       to: 8083
 #     - send: 7777
 #       to: 777

--- a/src/stubs/after.sh
+++ b/src/stubs/after.sh
@@ -4,6 +4,12 @@
 # add any commands you wish to this file and they will
 # be run after the Homestead machine is provisioned.
 
+
+#INSTALL SOME MISSING PARTS
+sudo apt-get install -y mongodb jq tmux
+
+
+#CORE SETUP
 cd /home/vagrant/oms-project/oms-neo-core
 
 cp .env.example .env
@@ -19,3 +25,26 @@ php artisan migrate
 php artisan key:generate
 php artisan db:seed
 php artisan config:cache
+
+
+#EVENTS SETUP
+cd ../oms-events
+
+npm install
+
+sudo ln -s /home/vagrant/oms-project/oms-events/nginx.conf /etc/nginx/sites-enabled/omsevents
+sudo systemctl reload nginx.service
+
+
+#get api key
+xtoken=$(curl --data "username=flaviu@glitch.ro&password=1234" localhost/api/login | jq -r ".message")
+
+apikey=$(curl --header "X-Auth-Token: "${xtoken}"" localhost/api/getSharedSecret | jq -r ".key")
+
+sed -i "s|CHANGEME|"${apikey}"|" lib/config/config*.json
+
+## New detached tmux session called ``Workstation''
+tmux new-session -s Workstation -d
+tmux neww -nNode node lib/server.js 
+sleep 10
+curl localhost:8083/api/registerMicroservice


### PR DESCRIPTION
add events integration at provisioning time
change ports, now standardised
edit readme to link to confluence, cutting shit short. Find all on wiki!

The provisioner also handshakes the API token with the core, so 
all that is left to do is to simply login to localhost:8000 and
accept the module registration
