### PR TITLE
add dynamic name for the vm

### DIFF
--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -4,6 +4,7 @@ memory: 1024
 cpus: 1
 provider: virtualbox
 hostname: aegee-virtual.nowhere.nodomain
+name: homestead-7
 
 authorize: ~/.ssh/id_rsa.pub
 


### PR DESCRIPTION
so in case of multiple provisionings there is no error

homestead-7 will be passed under sed and the datetime of provisioning will be appended
